### PR TITLE
add farming center v2 legacy-exit migration path

### DIFF
--- a/src/farming/contracts/FarmingCenterV2.sol
+++ b/src/farming/contracts/FarmingCenterV2.sol
@@ -46,15 +46,12 @@ contract FarmingCenterV2 is IFarmingCenter, IPositionFollower, Multicall {
   mapping(uint256 tokenId => uint256 enteredAt) public farmingEnteredAt;
 
   event LegacyExitCompleted(uint256 indexed tokenId, bytes32 indexed incentiveId, address indexed legacyFarmingCenter);
+  event FarmingEnteredAtUpdated(uint256 indexed tokenId, uint256 newTimestamp);
   event FarmingExitTimelockUpdated(uint256 oldTimelock, uint256 newTimelock);
   event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
   event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
-  constructor(
-    IAlgebraEternalFarming _eternalFarming,
-    INonfungiblePositionManager _nonfungiblePositionManager,
-    address _legacyFarmingCenter
-  ) {
+  constructor(IAlgebraEternalFarming _eternalFarming, INonfungiblePositionManager _nonfungiblePositionManager, address _legacyFarmingCenter) {
     require(_legacyFarmingCenter != address(0), 'Zero legacy farming center');
     eternalFarming = _eternalFarming;
     nonfungiblePositionManager = _nonfungiblePositionManager;
@@ -154,6 +151,10 @@ contract FarmingCenterV2 is IFarmingCenter, IPositionFollower, Multicall {
   /// @inheritdoc IPositionFollower
   function applyLiquidityDelta(uint256 tokenId, int256 liquidityDelta) external override {
     require(msg.sender == address(nonfungiblePositionManager), 'Only nonfungiblePosManager');
+    if (liquidityDelta > 0 && deposits[tokenId] != bytes32(0)) {
+      farmingEnteredAt[tokenId] = block.timestamp;
+      emit FarmingEnteredAtUpdated(tokenId, block.timestamp);
+    }
     if (liquidityDelta < 0 && deposits[tokenId] != bytes32(0)) {
       require(_isExitTimelockPassed(tokenId), 'Exit timelocked');
     }

--- a/src/farming/contracts/FarmingCenterV2.sol
+++ b/src/farming/contracts/FarmingCenterV2.sol
@@ -19,6 +19,10 @@ contract FarmingCenterV2 is IFarmingCenter, IPositionFollower, Multicall {
   IAlgebraEternalFarming public immutable override eternalFarming;
   /// @inheritdoc IFarmingCenter
   INonfungiblePositionManager public immutable override nonfungiblePositionManager;
+  /// @notice Owner allowed to manage configurable params
+  address public owner;
+  /// @notice Pending owner that must accept ownership transfer
+  address public pendingOwner;
   /// @inheritdoc IFarmingCenter
   address public immutable override algebraPoolDeployer;
   /// @notice Previous farming center address accepted for legacy exits
@@ -34,8 +38,17 @@ contract FarmingCenterV2 is IFarmingCenter, IPositionFollower, Multicall {
   mapping(bytes32 incentiveId => IncentiveKey incentiveKey) public override incentiveKeys;
   /// @notice Marks tokenIds that were exited through legacy farming-center state
   mapping(uint256 tokenId => bool exitedViaLegacy) public legacyExitCompleted;
+  /// @notice Maximum allowed lock duration for farming exit timelock
+  uint256 public constant maxFarmingExitTimelock = 30 minutes;
+  /// @notice Lock duration applied after enterFarming before exits/liquidity removal are allowed
+  uint256 public farmingExitTimelock = 7 minutes;
+  /// @notice Timestamp when a tokenId last entered farming
+  mapping(uint256 tokenId => uint256 enteredAt) public farmingEnteredAt;
 
   event LegacyExitCompleted(uint256 indexed tokenId, bytes32 indexed incentiveId, address indexed legacyFarmingCenter);
+  event FarmingExitTimelockUpdated(uint256 oldTimelock, uint256 newTimelock);
+  event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
+  event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
   constructor(
     IAlgebraEternalFarming _eternalFarming,
@@ -47,11 +60,39 @@ contract FarmingCenterV2 is IFarmingCenter, IPositionFollower, Multicall {
     nonfungiblePositionManager = _nonfungiblePositionManager;
     algebraPoolDeployer = _nonfungiblePositionManager.poolDeployer();
     legacyFarmingCenter = _legacyFarmingCenter;
+    owner = msg.sender;
+    emit OwnershipTransferred(address(0), msg.sender);
   }
 
   modifier isApprovedOrOwner(uint256 tokenId) {
     require(nonfungiblePositionManager.isApprovedOrOwner(msg.sender, tokenId), 'Not approved for token');
     _;
+  }
+
+  modifier onlyOwner() {
+    require(msg.sender == owner, 'Only owner');
+    _;
+  }
+
+  function transferOwnership(address newOwner) external onlyOwner {
+    require(newOwner != address(0), 'Zero owner');
+    pendingOwner = newOwner;
+    emit OwnershipTransferStarted(owner, newOwner);
+  }
+
+  function acceptOwnership() external {
+    require(msg.sender == pendingOwner, 'Only pending owner');
+    address oldOwner = owner;
+    owner = pendingOwner;
+    pendingOwner = address(0);
+    emit OwnershipTransferred(oldOwner, owner);
+  }
+
+  function setFarmingExitTimelock(uint256 newTimelock) external onlyOwner {
+    require(newTimelock <= maxFarmingExitTimelock, 'Timelock too large');
+    uint256 oldTimelock = farmingExitTimelock;
+    farmingExitTimelock = newTimelock;
+    emit FarmingExitTimelockUpdated(oldTimelock, newTimelock);
   }
 
   /// @inheritdoc IFarmingCenter
@@ -62,6 +103,7 @@ contract FarmingCenterV2 is IFarmingCenter, IPositionFollower, Multicall {
     require(deposits[tokenId] == bytes32(0), 'Token already farmed');
     legacyExitCompleted[tokenId] = false;
     deposits[tokenId] = incentiveId;
+    farmingEnteredAt[tokenId] = block.timestamp;
     nonfungiblePositionManager.switchFarmingStatus(tokenId, true);
 
     IAlgebraEternalFarming(eternalFarming).enterFarming(key, tokenId);
@@ -76,6 +118,7 @@ contract FarmingCenterV2 is IFarmingCenter, IPositionFollower, Multicall {
     bytes32 incentiveId = IncentiveId.compute(key);
     (bool isValidDeposit, bool isLegacyDeposit) = _resolveDepositSource(tokenId, incentiveId);
     require(isValidDeposit, 'Invalid incentiveId');
+    require(_isExitTimelockPassed(tokenId), 'Exit timelocked');
     if (isLegacyDeposit) {
       require(!legacyExitCompleted[tokenId], 'Legacy exit already completed');
       legacyExitCompleted[tokenId] = true;
@@ -102,19 +145,22 @@ contract FarmingCenterV2 is IFarmingCenter, IPositionFollower, Multicall {
 
   function _switchFarmingStatusOff(uint256 tokenId) internal {
     deposits[tokenId] = bytes32(0);
+    farmingEnteredAt[tokenId] = 0;
     if (nonfungiblePositionManager.tokenFarmedIn(tokenId) == address(this) || nonfungiblePositionManager.farmingCenter() == address(this)) {
       nonfungiblePositionManager.switchFarmingStatus(tokenId, false);
     }
   }
 
   /// @inheritdoc IPositionFollower
-  function applyLiquidityDelta(uint256 tokenId, int256) external override {
+  function applyLiquidityDelta(uint256 tokenId, int256 liquidityDelta) external override {
+    require(msg.sender == address(nonfungiblePositionManager), 'Only nonfungiblePosManager');
+    if (liquidityDelta < 0 && deposits[tokenId] != bytes32(0)) {
+      require(_isExitTimelockPassed(tokenId), 'Exit timelocked');
+    }
     _updatePosition(tokenId);
   }
 
   function _updatePosition(uint256 tokenId) private {
-    require(msg.sender == address(nonfungiblePositionManager), 'Only nonfungiblePosManager');
-
     bytes32 _eternalIncentiveId = deposits[tokenId];
     if (_eternalIncentiveId != bytes32(0)) {
       address tokenOwner = nonfungiblePositionManager.ownerOf(tokenId);
@@ -139,6 +185,11 @@ contract FarmingCenterV2 is IFarmingCenter, IPositionFollower, Multicall {
         }
       }
     }
+  }
+
+  function _isExitTimelockPassed(uint256 tokenId) internal view returns (bool) {
+    uint256 enteredAt = farmingEnteredAt[tokenId];
+    return enteredAt == 0 || block.timestamp >= enteredAt + farmingExitTimelock;
   }
 
   /// @inheritdoc IFarmingCenter

--- a/src/farming/contracts/FarmingCenterV2.sol
+++ b/src/farming/contracts/FarmingCenterV2.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.20;
+
+import '@cryptoalgebra/integral-core/contracts/interfaces/IAlgebraPool.sol';
+import '@cryptoalgebra/integral-core/contracts/interfaces/IERC20Minimal.sol';
+import '@cryptoalgebra/integral-periphery/contracts/interfaces/IPositionFollower.sol';
+import '@cryptoalgebra/integral-periphery/contracts/interfaces/INonfungiblePositionManager.sol';
+import '@cryptoalgebra/integral-periphery/contracts/base/Multicall.sol';
+import '@cryptoalgebra/integral-periphery/contracts/libraries/PoolAddress.sol';
+import '@cryptoalgebra/integral-base-plugin/contracts/interfaces/plugins/IFarmingPlugin.sol';
+
+import './interfaces/IFarmingCenter.sol';
+import './libraries/IncentiveId.sol';
+
+/// @title Algebra Integral 1.2.2 main farming contract (v2)
+/// @dev Manages farmings and performs entry, exit and other actions.
+contract FarmingCenterV2 is IFarmingCenter, IPositionFollower, Multicall {
+  /// @inheritdoc IFarmingCenter
+  IAlgebraEternalFarming public immutable override eternalFarming;
+  /// @inheritdoc IFarmingCenter
+  INonfungiblePositionManager public immutable override nonfungiblePositionManager;
+  /// @inheritdoc IFarmingCenter
+  address public immutable override algebraPoolDeployer;
+
+  /// @inheritdoc IFarmingCenter
+  mapping(address poolAddress => address virtualPoolAddress) public override virtualPoolAddresses;
+
+  /// @inheritdoc IFarmingCenter
+  mapping(uint256 tokenId => bytes32 incentiveId) public override deposits;
+
+  /// @inheritdoc IFarmingCenter
+  mapping(bytes32 incentiveId => IncentiveKey incentiveKey) public override incentiveKeys;
+  /// @notice Marks tokenIds that were exited through legacy farming-center state
+  mapping(uint256 tokenId => bool exitedViaLegacy) public legacyExitCompleted;
+
+  event LegacyExitCompleted(uint256 indexed tokenId, bytes32 indexed incentiveId, address indexed legacyFarmingCenter);
+
+  constructor(IAlgebraEternalFarming _eternalFarming, INonfungiblePositionManager _nonfungiblePositionManager) {
+    eternalFarming = _eternalFarming;
+    nonfungiblePositionManager = _nonfungiblePositionManager;
+    algebraPoolDeployer = _nonfungiblePositionManager.poolDeployer();
+  }
+
+  modifier isApprovedOrOwner(uint256 tokenId) {
+    require(nonfungiblePositionManager.isApprovedOrOwner(msg.sender, tokenId), 'Not approved for token');
+    _;
+  }
+
+  /// @inheritdoc IFarmingCenter
+  function enterFarming(IncentiveKey memory key, uint256 tokenId) external override isApprovedOrOwner(tokenId) {
+    bytes32 incentiveId = IncentiveId.compute(key);
+    if (address(incentiveKeys[incentiveId].pool) == address(0)) incentiveKeys[incentiveId] = key;
+
+    require(deposits[tokenId] == bytes32(0), 'Token already farmed');
+    legacyExitCompleted[tokenId] = false;
+    deposits[tokenId] = incentiveId;
+    nonfungiblePositionManager.switchFarmingStatus(tokenId, true);
+
+    IAlgebraEternalFarming(eternalFarming).enterFarming(key, tokenId);
+  }
+
+  /// @inheritdoc IFarmingCenter
+  function exitFarming(IncentiveKey memory key, uint256 tokenId) external override isApprovedOrOwner(tokenId) {
+    _exitFarming(key, tokenId, nonfungiblePositionManager.ownerOf(tokenId));
+  }
+
+  function _exitFarming(IncentiveKey memory key, uint256 tokenId, address tokenOwner) private {
+    bytes32 incentiveId = IncentiveId.compute(key);
+    (bool isValidDeposit, bool isLegacyDeposit, address legacyFarmingCenter) = _resolveDepositSource(tokenId, incentiveId);
+    require(isValidDeposit, 'Invalid incentiveId');
+    if (isLegacyDeposit) {
+      legacyExitCompleted[tokenId] = true;
+      emit LegacyExitCompleted(tokenId, incentiveId, legacyFarmingCenter);
+    }
+    _switchFarmingStatusOff(tokenId);
+
+    IAlgebraEternalFarming(eternalFarming).exitFarming(key, tokenId, tokenOwner);
+  }
+
+  function _resolveDepositSource(uint256 tokenId, bytes32 incentiveId) internal view returns (bool, bool, address) {
+    if (deposits[tokenId] == incentiveId) return (true, false, address(0));
+
+    address legacyFarmingCenter = nonfungiblePositionManager.tokenFarmedIn(tokenId);
+    if (legacyFarmingCenter == address(0) || legacyFarmingCenter == address(this) || legacyFarmingCenter.code.length == 0) {
+      return (false, false, address(0));
+    }
+
+    (bool success, bytes memory returndata) = legacyFarmingCenter.staticcall(abi.encodeWithSelector(IFarmingCenter.deposits.selector, tokenId));
+    if (!success || returndata.length < 32) return (false, false, address(0));
+
+    return (abi.decode(returndata, (bytes32)) == incentiveId, true, legacyFarmingCenter);
+  }
+
+  function _switchFarmingStatusOff(uint256 tokenId) internal {
+    deposits[tokenId] = bytes32(0);
+    if (nonfungiblePositionManager.tokenFarmedIn(tokenId) == address(this) || nonfungiblePositionManager.farmingCenter() == address(this)) {
+      nonfungiblePositionManager.switchFarmingStatus(tokenId, false);
+    }
+  }
+
+  /// @inheritdoc IPositionFollower
+  function applyLiquidityDelta(uint256 tokenId, int256) external override {
+    _updatePosition(tokenId);
+  }
+
+  function _updatePosition(uint256 tokenId) private {
+    require(msg.sender == address(nonfungiblePositionManager), 'Only nonfungiblePosManager');
+
+    bytes32 _eternalIncentiveId = deposits[tokenId];
+    if (_eternalIncentiveId != bytes32(0)) {
+      address tokenOwner = nonfungiblePositionManager.ownerOf(tokenId);
+      (, , , , , , , uint128 liquidity, , , , ) = nonfungiblePositionManager.positions(tokenId);
+
+      IncentiveKey memory key = incentiveKeys[_eternalIncentiveId];
+
+      if (liquidity == 0 || virtualPoolAddresses[address(key.pool)] == address(0)) {
+        _exitFarming(key, tokenId, tokenOwner); // nft burned or incentive deactivated, exit completely
+      } else {
+        IAlgebraEternalFarming(eternalFarming).exitFarming(key, tokenId, tokenOwner);
+
+        if (
+          IAlgebraEternalFarming(eternalFarming).isIncentiveDeactivated(IncentiveId.compute(key)) ||
+          IAlgebraEternalFarming(eternalFarming).isEmergencyWithdrawActivated()
+        ) {
+          // exit completely if the incentive has stopped (manually or automatically) or there is emergency
+          _switchFarmingStatusOff(tokenId);
+        } else {
+          // reenter with new liquidity value
+          IAlgebraEternalFarming(eternalFarming).enterFarming(key, tokenId);
+        }
+      }
+    }
+  }
+
+  /// @inheritdoc IFarmingCenter
+  function collectRewards(
+    IncentiveKey memory key,
+    uint256 tokenId
+  ) external override isApprovedOrOwner(tokenId) returns (uint256 reward, uint256 bonusReward) {
+    (reward, bonusReward) = eternalFarming.collectRewards(key, tokenId, nonfungiblePositionManager.ownerOf(tokenId));
+  }
+
+  /// @inheritdoc IFarmingCenter
+  function claimReward(IERC20Minimal rewardToken, address to, uint256 amountRequested) external override returns (uint256 rewardBalanceBefore) {
+    rewardBalanceBefore = eternalFarming.claimRewardFrom(rewardToken, msg.sender, to, amountRequested);
+  }
+
+  /// @inheritdoc IFarmingCenter
+  function connectVirtualPoolToPlugin(address newVirtualPool, IFarmingPlugin plugin, address deployer) external override {
+    IAlgebraPool pool = _checkParamsForVirtualPoolToggle(newVirtualPool, plugin, deployer);
+    require(plugin.incentive() == address(0), 'Another incentive is connected');
+    plugin.setIncentive(newVirtualPool); // revert is possible if the plugin does not allow
+    virtualPoolAddresses[address(pool)] = newVirtualPool;
+  }
+
+  /// @inheritdoc IFarmingCenter
+  function disconnectVirtualPoolFromPlugin(address virtualPool, IFarmingPlugin plugin, address deployer) external override {
+    IAlgebraPool pool = _checkParamsForVirtualPoolToggle(virtualPool, plugin, deployer);
+    if (plugin.incentive() == virtualPool) plugin.setIncentive(address(0)); // plugin _should_ allow to disconnect incentive
+    virtualPoolAddresses[address(pool)] = address(0);
+  }
+
+  /// @dev checks input params and fetches corresponding Algebra Integral pool
+  function _checkParamsForVirtualPoolToggle(address virtualPool, IFarmingPlugin plugin, address deployer) internal view returns (IAlgebraPool pool) {
+    require(msg.sender == address(eternalFarming), 'Only farming can call this');
+    require(virtualPool != address(0), 'Zero address as virtual pool');
+    pool = IAlgebraPool(plugin.getPool());
+    require(
+      address(pool) == PoolAddress.computeAddress(algebraPoolDeployer, PoolAddress.PoolKey(deployer, pool.token0(), pool.token1())),
+      'Invalid pool'
+    );
+  }
+}

--- a/src/farming/contracts/FarmingCenterV2.sol
+++ b/src/farming/contracts/FarmingCenterV2.sol
@@ -21,6 +21,8 @@ contract FarmingCenterV2 is IFarmingCenter, IPositionFollower, Multicall {
   INonfungiblePositionManager public immutable override nonfungiblePositionManager;
   /// @inheritdoc IFarmingCenter
   address public immutable override algebraPoolDeployer;
+  /// @notice Previous farming center address accepted for legacy exits
+  address public immutable legacyFarmingCenter;
 
   /// @inheritdoc IFarmingCenter
   mapping(address poolAddress => address virtualPoolAddress) public override virtualPoolAddresses;
@@ -35,10 +37,16 @@ contract FarmingCenterV2 is IFarmingCenter, IPositionFollower, Multicall {
 
   event LegacyExitCompleted(uint256 indexed tokenId, bytes32 indexed incentiveId, address indexed legacyFarmingCenter);
 
-  constructor(IAlgebraEternalFarming _eternalFarming, INonfungiblePositionManager _nonfungiblePositionManager) {
+  constructor(
+    IAlgebraEternalFarming _eternalFarming,
+    INonfungiblePositionManager _nonfungiblePositionManager,
+    address _legacyFarmingCenter
+  ) {
+    require(_legacyFarmingCenter != address(0), 'Zero legacy farming center');
     eternalFarming = _eternalFarming;
     nonfungiblePositionManager = _nonfungiblePositionManager;
     algebraPoolDeployer = _nonfungiblePositionManager.poolDeployer();
+    legacyFarmingCenter = _legacyFarmingCenter;
   }
 
   modifier isApprovedOrOwner(uint256 tokenId) {
@@ -66,9 +74,10 @@ contract FarmingCenterV2 is IFarmingCenter, IPositionFollower, Multicall {
 
   function _exitFarming(IncentiveKey memory key, uint256 tokenId, address tokenOwner) private {
     bytes32 incentiveId = IncentiveId.compute(key);
-    (bool isValidDeposit, bool isLegacyDeposit, address legacyFarmingCenter) = _resolveDepositSource(tokenId, incentiveId);
+    (bool isValidDeposit, bool isLegacyDeposit) = _resolveDepositSource(tokenId, incentiveId);
     require(isValidDeposit, 'Invalid incentiveId');
     if (isLegacyDeposit) {
+      require(!legacyExitCompleted[tokenId], 'Legacy exit already completed');
       legacyExitCompleted[tokenId] = true;
       emit LegacyExitCompleted(tokenId, incentiveId, legacyFarmingCenter);
     }
@@ -77,18 +86,18 @@ contract FarmingCenterV2 is IFarmingCenter, IPositionFollower, Multicall {
     IAlgebraEternalFarming(eternalFarming).exitFarming(key, tokenId, tokenOwner);
   }
 
-  function _resolveDepositSource(uint256 tokenId, bytes32 incentiveId) internal view returns (bool, bool, address) {
-    if (deposits[tokenId] == incentiveId) return (true, false, address(0));
+  function _resolveDepositSource(uint256 tokenId, bytes32 incentiveId) internal view returns (bool, bool) {
+    if (deposits[tokenId] == incentiveId) return (true, false);
 
-    address legacyFarmingCenter = nonfungiblePositionManager.tokenFarmedIn(tokenId);
-    if (legacyFarmingCenter == address(0) || legacyFarmingCenter == address(this) || legacyFarmingCenter.code.length == 0) {
-      return (false, false, address(0));
+    address tokenFarmedIn = nonfungiblePositionManager.tokenFarmedIn(tokenId);
+    if (tokenFarmedIn != legacyFarmingCenter) {
+      return (false, false);
     }
 
     (bool success, bytes memory returndata) = legacyFarmingCenter.staticcall(abi.encodeWithSelector(IFarmingCenter.deposits.selector, tokenId));
-    if (!success || returndata.length < 32) return (false, false, address(0));
+    if (!success || returndata.length < 32) return (false, false);
 
-    return (abi.decode(returndata, (bytes32)) == incentiveId, true, legacyFarmingCenter);
+    return (abi.decode(returndata, (bytes32)) == incentiveId, true);
   }
 
   function _switchFarmingStatusOff(uint256 tokenId) internal {

--- a/src/farming/scripts/deploy-v2.js
+++ b/src/farming/scripts/deploy-v2.js
@@ -1,0 +1,55 @@
+const hre = require('hardhat')
+const fs = require('fs')
+const path = require('path')
+const BasePluginV1FactoryComplied = require('@cryptoalgebra/integral-base-plugin/artifacts/contracts/BasePluginV1Factory.sol/BasePluginV1Factory.json')
+
+async function getFeeData() {
+  const { maxFeePerGas, maxPriorityFeePerGas } = await hre.ethers.provider.getFeeData()
+  return { maxFeePerGas, maxPriorityFeePerGas }
+}
+
+async function main() {
+  const deployDataPath = path.resolve(__dirname, '../../../' + (process.env.DEPLOY_ENV || '') + 'deploys.json')
+  const deploysData = JSON.parse(fs.readFileSync(deployDataPath, 'utf8'))
+
+  if (!deploysData.eternal) throw new Error('deploys.json missing "eternal" address')
+  if (!deploysData.nonfungiblePositionManager) throw new Error('deploys.json missing "nonfungiblePositionManager" address')
+  if (!deploysData.BasePluginV1Factory) throw new Error('deploys.json missing "BasePluginV1Factory" address')
+
+  const FarmingCenterV2Factory = await hre.ethers.getContractFactory('FarmingCenterV2')
+  const feeData1 = await getFeeData()
+  const farmingCenterV2 = await FarmingCenterV2Factory.deploy(deploysData.eternal, deploysData.nonfungiblePositionManager, { ...feeData1 })
+  await farmingCenterV2.waitForDeployment()
+  console.log('FarmingCenterV2 deployed to:', farmingCenterV2.target)
+
+  const eternalFarming = await hre.ethers.getContractAt('IAlgebraEternalFarming', deploysData.eternal)
+  const feeData2 = await getFeeData()
+  await (await eternalFarming.setFarmingCenterAddress(farmingCenterV2.target, { ...feeData2 })).wait()
+  console.log('Updated farming center address in eternal farming')
+
+  const pluginFactory = await hre.ethers.getContractAt(BasePluginV1FactoryComplied.abi, deploysData.BasePluginV1Factory)
+  const feeData3 = await getFeeData()
+  await (await pluginFactory.setFarmingAddress(farmingCenterV2.target, { ...feeData3 })).wait()
+  console.log('Updated farming center address in plugin factory')
+
+  const posManager = await hre.ethers.getContractAt('INonfungiblePositionManager', deploysData.nonfungiblePositionManager)
+  const feeData4 = await getFeeData()
+  await (await posManager.setFarmingCenter(farmingCenterV2.target, { ...feeData4 })).wait()
+  console.log('Updated farming center address in nonfungible position manager')
+
+  if (deploysData.fc && deploysData.fc !== farmingCenterV2.target) {
+    deploysData.fcV1 = deploysData.fc
+  }
+  deploysData.fc = farmingCenterV2.target
+  deploysData.fcV2 = farmingCenterV2.target
+
+  fs.writeFileSync(deployDataPath, JSON.stringify(deploysData), 'utf-8')
+  console.log('Saved updated addresses to:', deployDataPath)
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/src/farming/scripts/deploy-v2.js
+++ b/src/farming/scripts/deploy-v2.js
@@ -15,10 +15,17 @@ async function main() {
   if (!deploysData.eternal) throw new Error('deploys.json missing "eternal" address')
   if (!deploysData.nonfungiblePositionManager) throw new Error('deploys.json missing "nonfungiblePositionManager" address')
   if (!deploysData.BasePluginV1Factory) throw new Error('deploys.json missing "BasePluginV1Factory" address')
+  const legacyFarmingCenter = deploysData.fcV1 || deploysData.fc
+  if (!legacyFarmingCenter) throw new Error('deploys.json missing legacy farming center address ("fc" or "fcV1")')
 
   const FarmingCenterV2Factory = await hre.ethers.getContractFactory('FarmingCenterV2')
   const feeData1 = await getFeeData()
-  const farmingCenterV2 = await FarmingCenterV2Factory.deploy(deploysData.eternal, deploysData.nonfungiblePositionManager, { ...feeData1 })
+  const farmingCenterV2 = await FarmingCenterV2Factory.deploy(
+    deploysData.eternal,
+    deploysData.nonfungiblePositionManager,
+    legacyFarmingCenter,
+    { ...feeData1 }
+  )
   await farmingCenterV2.waitForDeployment()
   console.log('FarmingCenterV2 deployed to:', farmingCenterV2.target)
 

--- a/src/farming/test/unit/FarmingCenter.spec.ts
+++ b/src/farming/test/unit/FarmingCenter.spec.ts
@@ -468,7 +468,8 @@ describe('unit/FarmingCenter', () => {
       const farmingCenterFactory = await ethers.getContractFactory('FarmingCenterV2');
       const farmingCenterV2 = (await farmingCenterFactory.deploy(
         await context.eternalFarming.getAddress(),
-        await context.nft.getAddress()
+        await context.nft.getAddress(),
+        await context.farmingCenter.getAddress()
       )) as any as FarmingCenterV2;
 
       await context.eternalFarming.setFarmingCenterAddress(farmingCenterV2);

--- a/src/farming/test/unit/FarmingCenter.spec.ts
+++ b/src/farming/test/unit/FarmingCenter.spec.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'hardhat';
 import { Wallet } from 'ethers';
 import { loadFixture, impersonateAccount, stopImpersonatingAccount, setBalance } from '@nomicfoundation/hardhat-network-helpers';
-import { TestERC20, AlgebraEternalFarming, NftPosManagerMock, FarmingCenter } from '../../typechain';
+import { TestERC20, AlgebraEternalFarming, NftPosManagerMock, FarmingCenter, FarmingCenterV2 } from '../../typechain';
 import { algebraFixture, AlgebraFixtureType, mintPosition } from '../shared/fixtures';
 import {
   expect,
@@ -462,6 +462,33 @@ describe('unit/FarmingCenter', () => {
         },
         tokenIdEternal
       );
+    });
+
+    it('can exit in new farming center for legacy farm', async () => {
+      const farmingCenterFactory = await ethers.getContractFactory('FarmingCenterV2');
+      const farmingCenterV2 = (await farmingCenterFactory.deploy(
+        await context.eternalFarming.getAddress(),
+        await context.nft.getAddress()
+      )) as any as FarmingCenterV2;
+
+      await context.eternalFarming.setFarmingCenterAddress(farmingCenterV2);
+      await context.nft.setFarmingCenter(farmingCenterV2);
+      await context.pluginFactory.setFarmingAddress(farmingCenterV2);
+
+      await expect(
+        farmingCenterV2.connect(lpUser0).exitFarming(
+          {
+            rewardToken: context.rewardToken,
+            bonusRewardToken: context.bonusRewardToken,
+            pool: context.pool01,
+            nonce,
+          },
+          tokenIdEternal
+        )
+      ).to.not.be.reverted;
+
+      expect(await context.nft.tokenFarmedIn(tokenIdEternal)).to.be.eq(ZERO_ADDRESS);
+      expect(await farmingCenterV2.legacyExitCompleted(tokenIdEternal)).to.be.eq(true);
     });
   });
 


### PR DESCRIPTION
Introduce FarmingCenterV2 for legacy farm exits, add deployment script wiring for pointer migration, and cover the legacy exit flow in FarmingCenter tests while keeping FarmingCenter v1 unchanged.

Made-with: Cursor